### PR TITLE
Add terminal-based Flappy Bird

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,26 @@
 # KOREA
+
+This repository includes a simple Flappy Bird clone implemented in Python using the Pygame library.
+
+## Running the game
+
+1. Install the Pygame dependency:
+   ```bash
+   pip install pygame
+   ```
+2. Run the game with Python:
+   ```bash
+   python flappy.py
+   ```
+
+Press the space bar to flap the bird and avoid the green pipes. The score increases each time you successfully pass a pipe.
+
+## Running in the terminal
+
+If your environment does not support opening a Pygame window, you can play an ASCII version instead:
+
+```bash
+python flappy_terminal.py
+```
+
+Use the space bar to flap and press `q` to quit.

--- a/flappy.py
+++ b/flappy.py
@@ -1,0 +1,101 @@
+import pygame
+import random
+
+# Game constants
+WIDTH, HEIGHT = 400, 600
+GRAVITY = 0.25
+FLAP_STRENGTH = -6
+GAP_SIZE = 150
+PIPE_WIDTH = 70
+PIPE_SPEED = 3
+
+
+class Bird:
+    def __init__(self):
+        self.image = pygame.Surface((34, 24))
+        self.image.fill((255, 255, 0))
+        self.rect = self.image.get_rect(center=(50, HEIGHT // 2))
+        self.velocity = 0
+
+    def flap(self):
+        self.velocity = FLAP_STRENGTH
+
+    def update(self):
+        self.velocity += GRAVITY
+        self.rect.y += int(self.velocity)
+
+    def draw(self, screen):
+        screen.blit(self.image, self.rect)
+
+
+class Pipe:
+    def __init__(self, x):
+        self.top_height = random.randint(50, HEIGHT - GAP_SIZE - 50)
+        self.bottom_y = self.top_height + GAP_SIZE
+        self.top_rect = pygame.Rect(x, 0, PIPE_WIDTH, self.top_height)
+        self.bottom_rect = pygame.Rect(x, self.bottom_y, PIPE_WIDTH, HEIGHT - self.bottom_y)
+
+    def update(self):
+        self.top_rect.x -= PIPE_SPEED
+        self.bottom_rect.x -= PIPE_SPEED
+
+    def draw(self, screen):
+        pygame.draw.rect(screen, (0, 255, 0), self.top_rect)
+        pygame.draw.rect(screen, (0, 255, 0), self.bottom_rect)
+
+    def off_screen(self):
+        return self.top_rect.right < 0
+
+    def collides(self, bird_rect):
+        return self.top_rect.colliderect(bird_rect) or self.bottom_rect.colliderect(bird_rect)
+
+
+def main():
+    pygame.init()
+    screen = pygame.display.set_mode((WIDTH, HEIGHT))
+    clock = pygame.time.Clock()
+
+    bird = Bird()
+    pipes = [Pipe(WIDTH + 100)]
+    score = 0
+    font = pygame.font.SysFont(None, 36)
+
+    running = True
+    while running:
+        for event in pygame.event.get():
+            if event.type == pygame.QUIT:
+                running = False
+            if event.type == pygame.KEYDOWN and event.key == pygame.K_SPACE:
+                bird.flap()
+
+        bird.update()
+        if bird.rect.top <= 0 or bird.rect.bottom >= HEIGHT:
+            running = False
+
+        if pipes[-1].top_rect.x < WIDTH - 200:
+            pipes.append(Pipe(WIDTH))
+
+        for pipe in list(pipes):
+            pipe.update()
+            if pipe.collides(bird.rect):
+                running = False
+            if pipe.off_screen():
+                pipes.remove(pipe)
+                score += 1
+
+        screen.fill((135, 206, 235))
+        bird.draw(screen)
+        for pipe in pipes:
+            pipe.draw(screen)
+
+        score_surface = font.render(f"Score: {score}", True, (0, 0, 0))
+        screen.blit(score_surface, (10, 10))
+
+        pygame.display.flip()
+        clock.tick(60)
+
+    pygame.quit()
+
+
+if __name__ == "__main__":
+    main()

--- a/flappy_terminal.py
+++ b/flappy_terminal.py
@@ -1,0 +1,101 @@
+import curses
+import random
+import time
+
+# Constants for gameplay
+GRAVITY = 0.1
+FLAP_STRENGTH = -2
+PIPE_GAP = 6
+PIPE_SPACING = 20
+PIPE_SPEED = 1
+FRAME_DELAY = 0.05  # Seconds per frame (~20 FPS)
+
+class Bird:
+    def __init__(self, y):
+        self.y = float(y)
+        self.velocity = 0.0
+
+    def flap(self):
+        self.velocity = FLAP_STRENGTH
+
+    def update(self):
+        self.velocity += GRAVITY
+        self.y += self.velocity
+
+class Pipe:
+    def __init__(self, x, height, gap_start):
+        self.x = float(x)
+        self.height = height
+        self.gap_start = gap_start
+
+    def update(self):
+        self.x -= PIPE_SPEED
+
+    def is_offscreen(self):
+        return self.x < -1
+
+
+def run(stdscr):
+    curses.curs_set(0)
+    stdscr.nodelay(True)
+    stdscr.timeout(0)
+    height, width = stdscr.getmaxyx()
+    bird_x = width // 4
+    bird = Bird(height // 2)
+    pipes = []
+    frame_count = 0
+    score = 0
+
+    while True:
+        key = stdscr.getch()
+        if key in (ord('q'), ord('Q')):
+            break
+        if key == ord(' ') or key == curses.KEY_UP:
+            bird.flap()
+
+        if frame_count % PIPE_SPACING == 0:
+            gap_start = random.randint(2, max(2, height - PIPE_GAP - 2))
+            pipes.append(Pipe(width - 1, height, gap_start))
+
+        bird.update()
+        for pipe in pipes:
+            pipe.update()
+        if pipes and pipes[0].is_offscreen():
+            pipes.pop(0)
+            score += 1
+
+        # Collision detection
+        if bird.y < 0 or bird.y >= height:
+            break
+        for pipe in pipes:
+            if int(pipe.x) == bird_x:
+                if not (pipe.gap_start <= int(bird.y) <= pipe.gap_start + PIPE_GAP):
+                    return score
+
+        # Drawing
+        stdscr.erase()
+        for pipe in pipes:
+            x = int(pipe.x)
+            if 0 <= x < width:
+                for y in range(pipe.height):
+                    if not (pipe.gap_start <= y <= pipe.gap_start + PIPE_GAP):
+                        try:
+                            stdscr.addch(y, x, '#')
+                        except curses.error:
+                            pass
+        by = int(bird.y)
+        if 0 <= by < height:
+            try:
+                stdscr.addch(by, bird_x, 'O')
+            except curses.error:
+                pass
+        stdscr.addstr(0, 0, f'Score: {score}')
+        stdscr.refresh()
+        time.sleep(FRAME_DELAY)
+        frame_count += 1
+
+    return score
+
+if __name__ == '__main__':
+    final_score = curses.wrapper(run)
+    print('Game over! Your score:', final_score)


### PR DESCRIPTION
## Summary
- add a curses-based Flappy Bird in `flappy_terminal.py`
- document how to play the terminal version in README

## Testing
- `python -m py_compile flappy.py flappy_terminal.py`
- *(optional)* tried `timeout 2 python flappy_terminal.py` (fails in non-interactive shell)


------
https://chatgpt.com/codex/tasks/task_e_68417ae81828832f8c9f2aec07a32c54